### PR TITLE
Update github-enterprise graphql endpoint

### DIFF
--- a/docs/github-enterprise.md
+++ b/docs/github-enterprise.md
@@ -12,7 +12,7 @@ e.g. tfcmt.yaml
 
 ```yaml
 ghe_base_url: https://example.com
-ghe_graphql_endpoint: https://example.com/graphql
+ghe_graphql_endpoint: https://example.com/api/graphql
 ```
 
 * https://docs.github.com/en/enterprise-server@3.5/rest/overview/resources-in-the-rest-api#current-version


### PR DESCRIPTION
Thank you for this amazing tool

The Graphql endpoint in the docs is incorrect. This PR aims to rectify that my updating the api endpoint to the correct value.

To find the correct value I used GHA in an enterprise server and got the value of the `github.graphql_url `  context variable


ref - https://docs.github.com/en/actions/learn-github-actions/contexts#github-context