### PR TITLE
Remove unnecessary backquote

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -178,7 +178,7 @@ terraform:
       <details><summary>Details (Click me)</summary>
       {{wrapCode .CombinedOutput}}
       </details>
-      {{template "error_messages" .}}`
+      {{template "error_messages" .}}
     when_parse_error:
       template: |
         {{template "apply_title" .}}


### PR DESCRIPTION
It seems this backquote is unnecessary.

https://suzuki-shunsuke.github.io/tfcmt/config

<img width="664" alt="unnecessary backquote" src="https://github.com/suzuki-shunsuke/tfcmt-docs/assets/170014/db4128e1-e399-4e05-ab20-f6d84ffc6f65">
